### PR TITLE
Fixing a rounding error in the update timestamp code that caused the …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', artifactNumToKeepStr: '2', numToKeepStr: '2']]])
 
-node {
+node("master")
     def projectName = "ftl-sdk"
     
     def projectDir = pwd()+ "/${projectName}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', artifactNumToKeepStr: '2', numToKeepStr: '2']]])
 
-node("master")
+node("master") {
     def projectName = "ftl-sdk"
     
     def projectDir = pwd()+ "/${projectName}"

--- a/libftl/ftl_private.h
+++ b/libftl/ftl_private.h
@@ -185,7 +185,7 @@ typedef struct {
   uint32_t ssrc;
   uint32_t timestamp;
   int timestamp_clock;
-  int64_t prev_dts_usec;
+  int64_t base_dts_usec;
   uint16_t seq_num;
   uint16_t tmp_seq_num; // used for stats only
   BOOL nack_enabled;


### PR DESCRIPTION
…stream timestamps to drift about 10ms per minute. This would only happen if the incoming timestamps had a lot of variance in them.