### PR TITLE
Test connection api

### DIFF
--- a/libftl/ftl.h
+++ b/libftl/ftl.h
@@ -262,6 +262,8 @@ FTL_API ftl_status_t ftl_init();
 
 FTL_API ftl_status_t ftl_ingest_create(ftl_handle_t *ftl_handle, ftl_ingest_params_t *params);
 
+FTL_API ftl_status_t ftl_test_stream_key(ftl_handle_t *ftl_handle);
+
 FTL_API ftl_status_t ftl_ingest_connect(ftl_handle_t *ftl_handle);
 
 FTL_API int ftl_ingest_speed_test(ftl_handle_t *ftl_handle, int speed_kbps, int duration_ms);

--- a/libftl/handshake.c
+++ b/libftl/handshake.c
@@ -120,10 +120,10 @@ ftl_status_t _init_control_connection(ftl_stream_configuration_private_t *ftl) {
 
 ftl_status_t _test_stream_key_internal(ftl_stream_configuration_private_t *ftl)
 {
-    _init_control_connection(ftl);
-
-    if (ftl->ingest_socket <= 0) {
-        return FTL_SOCKET_NOT_CONNECTED;
+    ftl_status_t status = FTL_SUCCESS;
+    if ((status = _init_control_connection(ftl)) != FTL_SUCCESS)
+    {
+        return status;
     }
 
     ftl_response_code_t response_code = FTL_INGEST_RESP_UNKNOWN;

--- a/libftl/handshake.c
+++ b/libftl/handshake.c
@@ -114,8 +114,41 @@ ftl_status_t _init_control_connection(ftl_stream_configuration_private_t *ftl) {
   }
 
   ftl->ingest_socket = sock;
-  
+
   return FTL_SUCCESS;
+}
+
+ftl_status_t _test_stream_key_internal(ftl_stream_configuration_private_t *ftl)
+{
+    _init_control_connection(ftl);
+
+    if (ftl->ingest_socket <= 0) {
+        return FTL_SOCKET_NOT_CONNECTED;
+    }
+
+    ftl_response_code_t response_code = FTL_INGEST_RESP_UNKNOWN;
+    char response[MAX_INGEST_COMMAND_LEN];
+    do {
+        if (!ftl_get_hmac(ftl->ingest_socket, ftl->key, ftl->hmacBuffer)) {
+            FTL_LOG(ftl, FTL_LOG_ERROR, "could not get a signed HMAC!");
+            response_code = FTL_INGEST_NO_RESPONSE;
+            break;
+        }
+
+        if ((response_code = _ftl_send_command(ftl, TRUE, response, sizeof(response), "CONNECT %d $%s", ftl->channel_id, ftl->hmacBuffer)) != FTL_INGEST_RESP_OK) {
+            break;
+        }
+
+        return FTL_SUCCESS;
+
+    } while (0);
+
+    if (ftl->ingest_socket > 0) {
+        close_socket(ftl->ingest_socket);
+        ftl->ingest_socket = 0;
+    }
+
+    return response_code;
 }
 
 ftl_status_t _ingest_connect(ftl_stream_configuration_private_t *ftl) {
@@ -234,7 +267,7 @@ ftl_status_t _ingest_connect(ftl_stream_configuration_private_t *ftl) {
     }
 
     FTL_LOG(ftl, FTL_LOG_INFO, "Successfully connected to ingest.  Media will be sent to port %d\n", ftl->media.assigned_port);
-  
+
     return FTL_SUCCESS;
   } while (0);
 
@@ -280,7 +313,7 @@ ftl_status_t _ingest_disconnect(ftl_stream_configuration_private_t *ftl) {
     close_socket(ftl->ingest_socket);
     ftl->ingest_socket = 0;
   }
-  
+
   return FTL_SUCCESS;
 }
 
@@ -419,7 +452,7 @@ OS_THREAD_ROUTINE connection_status_thread(void *data)
       if (ms_since_ping > keepalive_is_late) {
         error_code = FTL_NO_PING_RESPONSE;
       }
-      
+
       FTL_LOG(ftl, FTL_LOG_ERROR, "ingest connection has dropped: %s\n", get_socket_error());
 
       ftl_clear_state(ftl, FTL_CXN_STATUS_THRD);


### PR DESCRIPTION
3 changes here
1) Fix for immediate connect and disconnect causing crash.
2) Fix for incorrect ingest stream key format causing crash. Essentially ingest_create on failure was crashing if you provide invalid format stream key .. like "asds".
3) created a light weight api called ftl_test_stream_key which I use to check if my cached stream key works fine.