### PR TITLE
Extend keepalive timeout to be more lenient in a constrained CPU scenario

### DIFF
--- a/libftl/handshake.c
+++ b/libftl/handshake.c
@@ -429,7 +429,7 @@ OS_THREAD_ROUTINE connection_status_thread(void *data)
   ftl_status_msg_t status;
   struct timeval last_ping, now;
   int ms_since_ping = 0;
-  int keepalive_is_late = KEEPALIVE_FREQUENCY_MS + KEEPALIVE_FREQUENCY_MS; // Add a 5s buffer to the wait time
+  int keepalive_is_late = 3 * KEEPALIVE_FREQUENCY_MS; // Add a 10s buffer to the wait time
 
   gettimeofday(&last_ping, NULL);
 


### PR DESCRIPTION
Our build has had this behavior for a month now. Seems good, and is at least not making things worse.