### PR TITLE
fixes from PVS-Studio

### DIFF
--- a/ftl_app/decode.c
+++ b/ftl_app/decode.c
@@ -20,6 +20,7 @@ h264_dec_obj_t * H264_Decode_Open()
 	
 	if ((obj->nalu_buf = malloc(10000000)) == NULL)
 	{
+		free(obj);
 		return NULL;
 	}
 
@@ -72,12 +73,7 @@ int H264_Decode_Nalu(h264_dec_obj_t* h264_dec_obj, unsigned char *nalu, int len)
 			//printf("Frame %d\n",  h264_dec_obj->slice.frame_num);
 		}
 
-		if(last_mba == -1)
-		{
-			last_mba = h264_dec_obj->slice.first_mb_in_slice;
-			last_frame_num = h264_dec_obj->slice.frame_num;
-		}
-		else if(last_frame_num == h264_dec_obj->slice.frame_num)
+		if((last_mba != -1) && (last_frame_num == h264_dec_obj->slice.frame_num))
 		{
 			if(last_mba >= h264_dec_obj->slice.first_mb_in_slice)
 				printf("Error: frame %d: current mba is %d, last was %d\n", h264_dec_obj->slice.frame_num, h264_dec_obj->slice.first_mb_in_slice, last_mba);

--- a/ftl_app/file_parser.c
+++ b/ftl_app/file_parser.c
@@ -40,6 +40,7 @@ int init_video(h264_obj_t *handle, const char *video_file) {
   if ((nalu->buf = malloc(10000000)) == NULL)
   {
 	  printf("Failed to allocate memory for bitstream\n");
+	  free(nalu);
 	  return -1;
   }
 
@@ -54,6 +55,7 @@ int init_video(h264_obj_t *handle, const char *video_file) {
   if ((nalu->buf = malloc(10000000)) == NULL)
   {
 	  printf("Failed to allocate memory for bitstream\n");
+	  free(nalu);
 	  return -1;
   }
 
@@ -248,7 +250,7 @@ int get_video_frame(h264_obj_t *handle, uint8_t *buf, uint32_t *length, int *las
  }
 
  uint16_t get_16bits(uint8_t **buf, uint32_t *len) {
-   uint16_t val;
+   uint16_t val = 0;
    uint32_t bytes = sizeof(uint16_t);
 
    if (*len >= bytes) {
@@ -266,7 +268,7 @@ int get_video_frame(h264_obj_t *handle, uint8_t *buf, uint32_t *length, int *las
  }
 
  uint32_t get_32bits(uint8_t **buf, uint32_t *len) {
-   uint32_t val;
+   uint32_t val = 0;
    uint32_t bytes = sizeof(uint32_t);
 
    if (*len >= bytes) {
@@ -284,7 +286,7 @@ int get_video_frame(h264_obj_t *handle, uint8_t *buf, uint32_t *length, int *las
  }
 
  uint64_t get_64bits(uint8_t **buf, uint32_t *len) {
-   uint64_t val;
+   uint64_t val = 0;
    uint32_t bytes = sizeof(uint64_t);
 
    if (*len >= bytes) {

--- a/libftl/ingest.c
+++ b/libftl/ingest.c
@@ -229,6 +229,7 @@ char * ingest_find_best(ftl_stream_configuration_private_t *ftl) {
   }
 
   if ((data = (_tmp_ingest_thread_data_t *)malloc(sizeof(_tmp_ingest_thread_data_t) * ftl->ingest_count)) == NULL) {
+	free(handle);
     return NULL;
   }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V519](https://www.viva64.com/en/w/v519/) The 'last_mba' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 77, 86. decode.c 86
[V519](https://www.viva64.com/en/w/v519/) The 'last_frame_num' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 78, 87. decode.c 87
[V614](https://www.viva64.com/en/w/v614/) Uninitialized variable 'val' used. file_parser.c 260
[V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'handle' pointer. A memory leak is possible. ingest.c 232