### PR TITLE
Fix some build issues around casts and malloc

### DIFF
--- a/libftl/ftl_helpers.c
+++ b/libftl/ftl_helpers.c
@@ -281,7 +281,7 @@ ftl_status_t _set_ingest_hostname(ftl_stream_configuration_private_t *ftl) {
 int _get_remote_ip(struct sockaddr *addr, size_t addrlen, char *remote_ip, size_t ip_len) {
 	if (addr->sa_family == AF_INET)
 	{
-		struct sockaddr_in *ipv4_addr = (struct sockaddr_in6 *)addr;
+		struct sockaddr_in *ipv4_addr = (struct sockaddr_in *)addr;
 
 		if (inet_ntop(AF_INET, &ipv4_addr->sin_addr.s_addr, remote_ip, ip_len) == NULL) {
 			return -1;

--- a/libftl/handshake.c
+++ b/libftl/handshake.c
@@ -82,11 +82,11 @@ ftl_status_t _init_control_connection(ftl_stream_configuration_private_t *ftl) {
     }
 
 	if (p->ai_family == AF_INET) {
-		struct sockaddr_in *ipv4_addr = p->ai_addr;
+		struct sockaddr_in *ipv4_addr = (struct sockaddr_in *)p->ai_addr;
 		inet_ntop(p->ai_family, &ipv4_addr->sin_addr, ingest_ip, sizeof(ingest_ip));
 	}
 	else if (p->ai_family == AF_INET6) {
-		struct sockaddr_in6 *ipv6_addr = p->ai_addr;
+		struct sockaddr_in6 *ipv6_addr = (struct sockaddr_in6 *)p->ai_addr;
 		inet_ntop(p->ai_family, &ipv6_addr->sin6_addr, ingest_ip, sizeof(ingest_ip));
 	}
 	else {

--- a/libftl/media.c
+++ b/libftl/media.c
@@ -60,7 +60,7 @@ ftl_status_t _get_addr_info(short family, char *ip, short port, struct sockaddr 
 			}
 
 			*addrlen = len;
-			*addr = ipv4_addr;
+			*addr = (struct sockaddr *)ipv4_addr;
 		}
 		else if (family == AF_INET6) {
 			struct sockaddr_in6 *ipv6_addr = NULL;
@@ -84,7 +84,7 @@ ftl_status_t _get_addr_info(short family, char *ip, short port, struct sockaddr 
 			}
 
 			*addrlen = len;
-			*addr = ipv6_addr;
+			*addr = (struct sockaddr *)ipv6_addr;
 		}
 	}
 	while (0);
@@ -1057,11 +1057,11 @@ OS_THREAD_ROUTINE recv_thread(void *data)
   char remote_ip[IPVX_ADDR_ASCII_LEN];
 
   if (ftl->socket_family == AF_INET) {
-	  addrinfo = &ipv4_addrinfo;
+	  addrinfo = (struct sockaddr *)&ipv4_addrinfo;
 	  addrinfo_len = sizeof(struct sockaddr_in);
   }
   else {
-	  addrinfo = &ipv6_addrinfo;
+	  addrinfo = (struct sockaddr *)&ipv6_addrinfo;
 	  addrinfo_len = sizeof(struct sockaddr_in6);
   }
 

--- a/libftl/win32/threads.c
+++ b/libftl/win32/threads.c
@@ -22,6 +22,7 @@
 * SOFTWARE.
 **/
 
+#include <stdlib.h>
 #include "threads.h"
 
 int os_init(){


### PR DESCRIPTION
Fix some incorrect or implicit casts. Also include stdlib.h for malloc to avoid using the compiler built-in definition.