### PR TITLE
Add ingest select logic

### DIFF
--- a/libftl/ftl.h
+++ b/libftl/ftl.h
@@ -321,6 +321,8 @@ FTL_API ftl_status_t ftl_ingest_destroy(ftl_handle_t *ftl_handle);
 
 FTL_API char* ftl_status_code_to_string(ftl_status_t status);
 
+FTL_API ftl_status_t find_closest_available_ingest(const char* ingestHosts[], int ingestsCount, char* bestIngestHostComputed);
+
 FTL_API ftl_status_t ftl_get_video_stats(ftl_handle_t* handle, uint64_t* frames_sent, uint64_t* nacks_received, uint64_t* rtt_recorded, uint64_t* frames_dropped, float* queue_fullness);
 
 FTL_API ftl_status_t ftl_adaptive_bitrate_thread(

--- a/libftl/ftl.h
+++ b/libftl/ftl.h
@@ -321,7 +321,7 @@ FTL_API ftl_status_t ftl_ingest_destroy(ftl_handle_t *ftl_handle);
 
 FTL_API char* ftl_status_code_to_string(ftl_status_t status);
 
-FTL_API ftl_status_t find_closest_available_ingest(const char* ingestHosts[], int ingestsCount, char* bestIngestHostComputed);
+FTL_API ftl_status_t ftl_find_closest_available_ingest(const char* ingestHosts[], int ingestsCount, char* bestIngestHostComputed);
 
 FTL_API ftl_status_t ftl_get_video_stats(ftl_handle_t* handle, uint64_t* frames_sent, uint64_t* nacks_received, uint64_t* rtt_recorded, uint64_t* frames_dropped, float* queue_fullness);
 

--- a/libftl/ingest.c
+++ b/libftl/ingest.c
@@ -94,55 +94,59 @@ OS_THREAD_ROUTINE _ingest_get_rtt(void *data) {
 
 ftl_status_t ftl_find_closest_available_ingest(const char* ingestHosts[], int ingestsCount, char* bestIngestHostComputed)
 {
-    ftl_ingest_t* ingestElements;
-    OS_THREAD_HANDLE *handles;
-    _tmp_ingest_thread_data_t *data;
+    if (ingestHosts == NULL || ingestCount <= 0) {
+      return FTL_UNKNOWN_ERROR_CODE;
+    }
+    
+    ftl_ingest_t* ingestElements = NULL;
+    OS_THREAD_HANDLE *handles = NULL;
+    _tmp_ingest_thread_data_t *data = NULL;
     
     int i;
 
     ftl_status_t ret_status = FTL_SUCCESS;
     do {
-      if ((ingestElements = malloc(sizeof(ftl_ingest_t) * ingestsCount)) == NULL) {
-        ret_status = FTL_MALLOC_FAILURE;
-        break;
-      }
-
-      for (i = 0; i < ingestsCount; i++) {
-        size_t host_len = strlen(ingestHosts[i]) + 1;
-        if ((ingestElements[i].hostname = malloc(host_len)) == NULL) {
-          ret_status = FTL_MALLOC_FAILURE;
-          break;
+        if ((ingestElements = malloc(sizeof(ftl_ingest_t) * ingestsCount)) == NULL) {
+            ret_status = FTL_MALLOC_FAILURE;
+            break;
         }
-        strcpy_s(ingestElements[i].hostname, host_len, ingestHosts[i]);
-        ingestElements[i].rtt = 1000;
-        ingestElements[i].next = NULL;
-      }
-      if (ret_status != FTL_SUCCESS) {
-        break;
-      }
 
-      if ((handles = (OS_THREAD_HANDLE *)malloc(sizeof(OS_THREAD_HANDLE) * ingestsCount)) == NULL) {
-        ret_status = FTL_MALLOC_FAILURE;
-        break;
-      }
+        for (i = 0; i < ingestsCount; i++) {
+            size_t host_len = strlen(ingestHosts[i]) + 1;
+            if ((ingestElements[i].hostname = malloc(host_len)) == NULL) {
+                ret_status = FTL_MALLOC_FAILURE;
+                break;
+            }
+            strcpy_s(ingestElements[i].hostname, host_len, ingestHosts[i]);
+            ingestElements[i].rtt = 1000;
+            ingestElements[i].next = NULL;
+        }
+        if (ret_status != FTL_SUCCESS) {
+            break;
+        }
 
-      if ((data = (_tmp_ingest_thread_data_t *)malloc(sizeof(_tmp_ingest_thread_data_t) * ingestsCount)) == NULL) {
-        ret_status = FTL_MALLOC_FAILURE;
-        break;
-      }
+        if ((handles = (OS_THREAD_HANDLE *)malloc(sizeof(OS_THREAD_HANDLE) * ingestsCount)) == NULL) {
+            ret_status = FTL_MALLOC_FAILURE;
+            break;
+        }
+
+        if ((data = (_tmp_ingest_thread_data_t *)malloc(sizeof(_tmp_ingest_thread_data_t) * ingestsCount)) == NULL) {
+            ret_status = FTL_MALLOC_FAILURE;
+            break;
+        }
     } while (0);
 
     // malloc failed, cleanup
     if (ret_status != FTL_SUCCESS) {
-      if (ingestElements != NULL) {
-        for (i = 0; i < ingestsCount; i++) {
-          free(ingestElements[i].hostname);
+        if (ingestElements != NULL) {
+            for (i = 0; i < ingestsCount; i++) {
+              free(ingestElements[i].hostname);
+            }
         }
-      }
-      free(ingestElements);
-      free(handles);
-      free(data);
-      return ret_status;
+        free(ingestElements);
+        free(handles);
+        free(data);
+        return ret_status;
     }
 
     ftl_ingest_t *best = NULL;
@@ -184,9 +188,9 @@ ftl_status_t ftl_find_closest_available_ingest(const char* ingestHosts[], int in
     free(data);
 
     if (best) {
-      strcpy_s(bestIngestHostComputed, strlen(best->hostname), best->hostname);
+        strcpy_s(bestIngestHostComputed, strlen(best->hostname), best->hostname);
     } else {
-      ret_status = FTL_UNKNOWN_ERROR_CODE;
+        ret_status = FTL_UNKNOWN_ERROR_CODE;
     }
 
     for (i = 0; i < ingestsCount; i++) {

--- a/libftl/ingest.c
+++ b/libftl/ingest.c
@@ -106,7 +106,7 @@ ftl_status_t ftl_find_closest_available_ingest(const char* ingestHosts[], int in
 
     ftl_status_t ret_status = FTL_SUCCESS;
     do {
-        if ((ingestElements = malloc(sizeof(ftl_ingest_t) * ingestsCount)) == NULL) {
+        if ((ingestElements = calloc(ingestsCount, sizeof(ftl_ingest_t))) == NULL) {
             ret_status = FTL_MALLOC_FAILURE;
             break;
         }

--- a/libftl/ingest.c
+++ b/libftl/ingest.c
@@ -94,10 +94,10 @@ OS_THREAD_ROUTINE _ingest_get_rtt(void *data) {
 
 ftl_status_t ftl_find_closest_available_ingest(const char* ingestHosts[], int ingestsCount, char* bestIngestHostComputed)
 {
-    if (ingestHosts == NULL || ingestCount <= 0) {
+    if (ingestHosts == NULL || ingestsCount <= 0) {
       return FTL_UNKNOWN_ERROR_CODE;
     }
-    
+
     ftl_ingest_t* ingestElements = NULL;
     OS_THREAD_HANDLE *handles = NULL;
     _tmp_ingest_thread_data_t *data = NULL;


### PR DESCRIPTION
For clients not using built-in auto ingest logic, they will get a list of ingest servers on the native platform. So this function is required for those clients to choose the best ingest server. 