### PR TITLE
Fix oacr build warnings

### DIFF
--- a/libftl/ftl_private.h
+++ b/libftl/ftl_private.h
@@ -131,6 +131,8 @@
 #define strcpy_s(dst, dstsz, src) strcpy(dst, src)
 #define _strdup(src) strdup(src)
 #define sscanf_s sscanf
+#define memcpy_s(dst, dstsz, src, cnt) memcpy(dst, src, cnt)
+#define vsnprintf_s(buf, bufsz, cnt, fmt, __VA_ARGS__) vsnprintf(buf, cnt, fmt, __VA_ARGS__)
 #endif
 
 typedef enum {

--- a/libftl/ftl_private.h
+++ b/libftl/ftl_private.h
@@ -132,7 +132,7 @@
 #define _strdup(src) strdup(src)
 #define sscanf_s sscanf
 #define memcpy_s(dst, dstsz, src, cnt) memcpy(dst, src, cnt)
-#define vsnprintf_s(buf, bufsz, cnt, fmt, __VA_ARGS__) vsnprintf(buf, cnt, fmt, __VA_ARGS__)
+#define vsnprintf_s(buf, bufsz, cnt, fmt, ...) vsnprintf(buf, cnt, fmt, __VA_ARGS__)
 #endif
 
 typedef enum {

--- a/libftl/handshake.c
+++ b/libftl/handshake.c
@@ -63,7 +63,11 @@ ftl_status_t _init_control_connection(ftl_stream_configuration_private_t *ftl) {
     return retval;
   }
   
+  // Suppressing getaddrinfo warning here, Windows prefers GetAddrInfoW,etc. but this doesn't exist on Linux
+  #pragma warning(push)
+  #pragma warning(disable:38026)
   err = getaddrinfo(ftl->ingest_hostname, ingest_port_str, &hints, &resolved_names);
+  #pragma warning(pop)
   if (err != 0) {
     FTL_LOG(ftl, FTL_LOG_ERROR, "getaddrinfo failed to look up ingest address %s.", ftl->ingest_hostname);
     FTL_LOG(ftl, FTL_LOG_ERROR, "gai error was: %s", gai_strerror(err));
@@ -366,7 +370,7 @@ static ftl_response_code_t _ftl_send_command(ftl_stream_configuration_private_t 
 
     memset(buf, 0, buflen);
 
-    len = vsnprintf(buf, buflen, format, valist);
+    len = vsnprintf_s(buf, buflen, MAX_INGEST_COMMAND_LEN, format, valist);
 
     va_end(valist);
 

--- a/libftl/ingest.c
+++ b/libftl/ingest.c
@@ -36,7 +36,12 @@ static int _ping_server(const char *hostname, int port) {
 
   snprintf(port_str, 10, "%d", port);
   
+  // Suppressing getaddrinfo warning here, Windows prefers GetAddrInfoW,etc. but this doesn't exist on Linux
+  #pragma warning(push)
+  #pragma warning(disable:38026)
    err = getaddrinfo(hostname, port_str, &hints, &resolved_names);
+  #pragma warning(pop)
+
   if (err != 0) {
     return FTL_DNS_FAILURE;
   }
@@ -90,115 +95,6 @@ OS_THREAD_ROUTINE _ingest_get_rtt(void *data) {
     }
 
     return 0;
-}
-
-ftl_status_t ftl_find_closest_available_ingest(const char* ingestHosts[], int ingestsCount, char* bestIngestHostComputed)
-{
-    if (ingestHosts == NULL || ingestsCount <= 0) {
-      return FTL_UNKNOWN_ERROR_CODE;
-    }
-
-    ftl_ingest_t* ingestElements = NULL;
-    OS_THREAD_HANDLE *handles = NULL;
-    _tmp_ingest_thread_data_t *data = NULL;
-    
-    int i;
-
-    ftl_status_t ret_status = FTL_SUCCESS;
-    do {
-        if ((ingestElements = calloc(ingestsCount, sizeof(ftl_ingest_t))) == NULL) {
-            ret_status = FTL_MALLOC_FAILURE;
-            break;
-        }
-
-        for (i = 0; i < ingestsCount; i++) {
-            size_t host_len = strlen(ingestHosts[i]) + 1;
-            if ((ingestElements[i].hostname = malloc(host_len)) == NULL) {
-                ret_status = FTL_MALLOC_FAILURE;
-                break;
-            }
-            strcpy_s(ingestElements[i].hostname, host_len, ingestHosts[i]);
-            ingestElements[i].rtt = 1000;
-            ingestElements[i].next = NULL;
-        }
-        if (ret_status != FTL_SUCCESS) {
-            break;
-        }
-
-        if ((handles = (OS_THREAD_HANDLE *)malloc(sizeof(OS_THREAD_HANDLE) * ingestsCount)) == NULL) {
-            ret_status = FTL_MALLOC_FAILURE;
-            break;
-        }
-
-        if ((data = (_tmp_ingest_thread_data_t *)malloc(sizeof(_tmp_ingest_thread_data_t) * ingestsCount)) == NULL) {
-            ret_status = FTL_MALLOC_FAILURE;
-            break;
-        }
-    } while (0);
-
-    // malloc failed, cleanup
-    if (ret_status != FTL_SUCCESS) {
-        if (ingestElements != NULL) {
-            for (i = 0; i < ingestsCount; i++) {
-              free(ingestElements[i].hostname);
-            }
-        }
-        free(ingestElements);
-        free(handles);
-        free(data);
-        return ret_status;
-    }
-
-    ftl_ingest_t *best = NULL;
-    struct timeval start, stop, delta;
-    gettimeofday(&start, NULL);
-
-    /*query all the ingests about cpu and rtt*/
-    for (i = 0; i < ingestsCount; i++) {
-        handles[i] = 0;
-        data[i].ingest = &ingestElements[i];
-        data[i].ftl = NULL;
-        os_create_thread(&handles[i], NULL, _ingest_get_rtt, &data[i]);
-        sleep_ms(5); //space out the pings
-    }
-
-    /*wait for all the ingests to complete*/
-    for (i = 0; i < ingestsCount; i++) {
-
-        if (handles[i] != 0) {
-            os_wait_thread(handles[i]);
-        }
-
-        if (best == NULL || ingestElements[i].rtt < best->rtt) {
-            best = &ingestElements[i];
-        }
-    }
-
-    gettimeofday(&stop, NULL);
-    timeval_subtract(&delta, &stop, &start);
-    int ms = (int)timeval_to_ms(&delta);
-
-    for (i = 0; i < ingestsCount; i++) {
-        if (handles[i] != 0) {
-            os_destroy_thread(handles[i]);
-        }
-    }
-
-    free(handles);
-    free(data);
-
-    if (best) {
-        strcpy_s(bestIngestHostComputed, strlen(best->hostname), best->hostname);
-    } else {
-        ret_status = FTL_UNKNOWN_ERROR_CODE;
-    }
-
-    for (i = 0; i < ingestsCount; i++) {
-        free(ingestElements[i].hostname);
-    }
-    free(ingestElements);
-
-    return ret_status;
 }
 
 #ifndef DISABLE_AUTO_INGEST

--- a/libftl/ingest.c
+++ b/libftl/ingest.c
@@ -97,6 +97,115 @@ OS_THREAD_ROUTINE _ingest_get_rtt(void *data) {
     return 0;
 }
 
+ftl_status_t ftl_find_closest_available_ingest(const char* ingestHosts[], int ingestsCount, char* bestIngestHostComputed)
+{
+    if (ingestHosts == NULL || ingestsCount <= 0) {
+      return FTL_UNKNOWN_ERROR_CODE;
+    }
+
+    ftl_ingest_t* ingestElements = NULL;
+    OS_THREAD_HANDLE *handles = NULL;
+    _tmp_ingest_thread_data_t *data = NULL;
+    
+    int i;
+
+    ftl_status_t ret_status = FTL_SUCCESS;
+    do {
+        if ((ingestElements = calloc(ingestsCount, sizeof(ftl_ingest_t))) == NULL) {
+            ret_status = FTL_MALLOC_FAILURE;
+            break;
+        }
+
+        for (i = 0; i < ingestsCount; i++) {
+            size_t host_len = strlen(ingestHosts[i]) + 1;
+            if ((ingestElements[i].hostname = malloc(host_len)) == NULL) {
+                ret_status = FTL_MALLOC_FAILURE;
+                break;
+            }
+            strcpy_s(ingestElements[i].hostname, host_len, ingestHosts[i]);
+            ingestElements[i].rtt = 1000;
+            ingestElements[i].next = NULL;
+        }
+        if (ret_status != FTL_SUCCESS) {
+            break;
+        }
+
+        if ((handles = (OS_THREAD_HANDLE *)malloc(sizeof(OS_THREAD_HANDLE) * ingestsCount)) == NULL) {
+            ret_status = FTL_MALLOC_FAILURE;
+            break;
+        }
+
+        if ((data = (_tmp_ingest_thread_data_t *)malloc(sizeof(_tmp_ingest_thread_data_t) * ingestsCount)) == NULL) {
+            ret_status = FTL_MALLOC_FAILURE;
+            break;
+        }
+    } while (0);
+
+    // malloc failed, cleanup
+    if (ret_status != FTL_SUCCESS) {
+        if (ingestElements != NULL) {
+            for (i = 0; i < ingestsCount; i++) {
+              free(ingestElements[i].hostname);
+            }
+        }
+        free(ingestElements);
+        free(handles);
+        free(data);
+        return ret_status;
+    }
+
+    ftl_ingest_t *best = NULL;
+    struct timeval start, stop, delta;
+    gettimeofday(&start, NULL);
+
+    /*query all the ingests about cpu and rtt*/
+    for (i = 0; i < ingestsCount; i++) {
+        handles[i] = 0;
+        data[i].ingest = &ingestElements[i];
+        data[i].ftl = NULL;
+        os_create_thread(&handles[i], NULL, _ingest_get_rtt, &data[i]);
+        sleep_ms(5); //space out the pings
+    }
+
+    /*wait for all the ingests to complete*/
+    for (i = 0; i < ingestsCount; i++) {
+
+        if (handles[i] != 0) {
+            os_wait_thread(handles[i]);
+        }
+
+        if (best == NULL || ingestElements[i].rtt < best->rtt) {
+            best = &ingestElements[i];
+        }
+    }
+
+    gettimeofday(&stop, NULL);
+    timeval_subtract(&delta, &stop, &start);
+    int ms = (int)timeval_to_ms(&delta);
+
+    for (i = 0; i < ingestsCount; i++) {
+        if (handles[i] != 0) {
+            os_destroy_thread(handles[i]);
+        }
+    }
+
+    free(handles);
+    free(data);
+
+    if (best) {
+        strcpy_s(bestIngestHostComputed, strlen(best->hostname), best->hostname);
+    } else {
+        ret_status = FTL_UNKNOWN_ERROR_CODE;
+    }
+
+    for (i = 0; i < ingestsCount; i++) {
+        free(ingestElements[i].hostname);
+    }
+    free(ingestElements);
+
+    return ret_status;
+}
+
 #ifndef DISABLE_AUTO_INGEST
 OS_THREAD_ROUTINE _ingest_get_hosts(ftl_stream_configuration_private_t *ftl);
 

--- a/libftl/logging.c
+++ b/libftl/logging.c
@@ -32,7 +32,7 @@ void ftl_log_msg(ftl_stream_configuration_private_t *ftl, ftl_log_severity_t log
 
   m.msg.log.log_level = log_level;
   va_start(args, fmt);
-  vsnprintf(m.msg.log.string, sizeof(m.msg.log.string), fmt, args);
+  vsnprintf_s(m.msg.log.string, sizeof(m.msg.log.string), sizeof(m.msg.log.string), fmt, args);
   va_end(args);
 
   enqueue_status_msg(ftl, &m);

--- a/libftl/logging.c
+++ b/libftl/logging.c
@@ -32,7 +32,7 @@ void ftl_log_msg(ftl_stream_configuration_private_t *ftl, ftl_log_severity_t log
 
   m.msg.log.log_level = log_level;
   va_start(args, fmt);
-  vsnprintf_s(m.msg.log.string, strlen(m.msg.log.string), sizeof(m.msg.log.string), fmt, args);
+  vsnprintf_s(m.msg.log.string, sizeof(m.msg.log.string), _TRUNCATE, fmt, args);
   va_end(args);
 
   enqueue_status_msg(ftl, &m);

--- a/libftl/logging.c
+++ b/libftl/logging.c
@@ -22,6 +22,7 @@
  * SOFTWARE.
  **/
 
+#include <stdlib.h> 
 #include "ftl.h"
 #include "ftl_private.h"
 

--- a/libftl/logging.c
+++ b/libftl/logging.c
@@ -32,7 +32,7 @@ void ftl_log_msg(ftl_stream_configuration_private_t *ftl, ftl_log_severity_t log
 
   m.msg.log.log_level = log_level;
   va_start(args, fmt);
-  vsnprintf_s(m.msg.log.string, sizeof(m.msg.log.string), sizeof(m.msg.log.string), fmt, args);
+  vsnprintf_s(m.msg.log.string, strlen(m.msg.log.string), sizeof(m.msg.log.string), fmt, args);
   va_end(args);
 
   enqueue_status_msg(ftl, &m);

--- a/libftl/media.c
+++ b/libftl/media.c
@@ -1539,10 +1539,12 @@ FTL_API ftl_status_t ftl_get_video_stats(
 BOOL is_bitrate_reduction_required(
   const float nacks_to_frames_ratio,
   const float avg_rtt,
+  const uint64_t avg_frames_dropped_per_second,
   const float queue_fullness)
 {
   // TODO : Improve estimation of rtt stability.
   if (nacks_to_frames_ratio > MIN_NACKS_RECEIVED_TO_PACKETS_SENT_RATIO_FOR_BITRATE_DOWNGRADE
+    || avg_frames_dropped_per_second > 3
     || avg_rtt > MIN_AVG_RTT_TO_DEEM_BW_CONSTRAINED
     || queue_fullness > MIN_QUEUE_FULLNESS_TO_DEEM_BW_CONSTRAINED
     )
@@ -1781,9 +1783,9 @@ OS_THREAD_ROUTINE adaptive_bitrate_thread(void* data)
 
       // Check if bandwidth is constrained and bitrate reduction is required. The bandwidth can be constrained for two reasons.
       // Either the available bandwidth has decreased, or we tried to upgrade the bitrate and its too excessive.
-      if (is_bitrate_reduction_required(nacks_to_frames_ratio, avg_rtt, queue_fullness))
+      if (is_bitrate_reduction_required(nacks_to_frames_ratio, avg_rtt, avg_frames_dropped_per_second, queue_fullness))
       {
-        FTL_LOG(params->handle->priv, FTL_LOG_INFO, "Bitrate reduction required. Nacks Received %ull , Frames Sent %ull rtt %4.2f queue_fullness %4.2f",
+        FTL_LOG(params->handle->priv, FTL_LOG_INFO, "Bitrate reduction required. Nacks Received %d , Frames Sent %d rtt %d queue_fullness %4.2f",
           nacks_received_total,
           frames_sent_total,
           avg_rtt,

--- a/libftl/media.c
+++ b/libftl/media.c
@@ -842,7 +842,7 @@ static int _media_send_slot(ftl_stream_configuration_private_t *ftl, nack_slot_t
   int pkt_len;
 
   os_lock_mutex(&ftl->media.mutex);
-  memcpy_s(pkt, sizeof(pkt), slot->packet, slot->len);
+  memcpy_s(pkt, sizeof(pkt) * MAX_PACKET_BUFFER, slot->packet, slot->len);
   pkt_len = slot->len;
   os_unlock_mutex(&ftl->media.mutex);
 

--- a/libftl/media.c
+++ b/libftl/media.c
@@ -842,7 +842,7 @@ static int _media_send_slot(ftl_stream_configuration_private_t *ftl, nack_slot_t
   int pkt_len;
 
   os_lock_mutex(&ftl->media.mutex);
-  memcpy(pkt, slot->packet, slot->len);
+  memcpy_s(pkt, sizeof(pkt), slot->packet, slot->len);
   pkt_len = slot->len;
   os_unlock_mutex(&ftl->media.mutex);
 
@@ -1539,12 +1539,10 @@ FTL_API ftl_status_t ftl_get_video_stats(
 BOOL is_bitrate_reduction_required(
   const float nacks_to_frames_ratio,
   const float avg_rtt,
-  const uint64_t avg_frames_dropped_per_second,
   const float queue_fullness)
 {
   // TODO : Improve estimation of rtt stability.
   if (nacks_to_frames_ratio > MIN_NACKS_RECEIVED_TO_PACKETS_SENT_RATIO_FOR_BITRATE_DOWNGRADE
-    || avg_frames_dropped_per_second > 3
     || avg_rtt > MIN_AVG_RTT_TO_DEEM_BW_CONSTRAINED
     || queue_fullness > MIN_QUEUE_FULLNESS_TO_DEEM_BW_CONSTRAINED
     )
@@ -1783,9 +1781,9 @@ OS_THREAD_ROUTINE adaptive_bitrate_thread(void* data)
 
       // Check if bandwidth is constrained and bitrate reduction is required. The bandwidth can be constrained for two reasons.
       // Either the available bandwidth has decreased, or we tried to upgrade the bitrate and its too excessive.
-      if (is_bitrate_reduction_required(nacks_to_frames_ratio, avg_rtt, avg_frames_dropped_per_second, queue_fullness))
+      if (is_bitrate_reduction_required(nacks_to_frames_ratio, avg_rtt, queue_fullness))
       {
-        FTL_LOG(params->handle->priv, FTL_LOG_INFO, "Bitrate reduction required. Nacks Received %d , Frames Sent %d rtt %d queue_fullness %4.2f",
+        FTL_LOG(params->handle->priv, FTL_LOG_INFO, "Bitrate reduction required. Nacks Received %ull , Frames Sent %ull rtt %4.2f queue_fullness %4.2f",
           nacks_received_total,
           frames_sent_total,
           avg_rtt,


### PR DESCRIPTION
Fixed TVS oacr warnings that appear when built for console code.
Windows wants us to check buffer size, while this is not required on Linux, so two new defines added for memcpy_s and vsnprintf_s.
Also Windows suggest we use GetAddrInfoW which takes a windows wide string, this method does not work with Linux. So we will suppress the warning.