### PR TITLE
Add support for Restream.io stream keys

### DIFF
--- a/libftl/ftl-sdk.c
+++ b/libftl/ftl-sdk.c
@@ -418,7 +418,7 @@ FTL_API char* ftl_status_code_to_string(ftl_status_t status) {
 BOOL _get_chan_id_and_key(const char *stream_key, uint32_t *chan_id, char *key) {
   size_t len, i = 0;
 
-  if (stream_key == null) {
+  if (stream_key == NULL) {
     return FALSE;
   }
 

--- a/libftl/ftl-sdk.c
+++ b/libftl/ftl-sdk.c
@@ -417,25 +417,40 @@ FTL_API char* ftl_status_code_to_string(ftl_status_t status) {
 
 BOOL _get_chan_id_and_key(const char *stream_key, uint32_t *chan_id, char *key) {
   size_t len, i = 0;
-  
+
+  char * copy_of_key = _strdup(stream_key);
+
   len = strlen(stream_key);
+
+  // Restream.io stream keys start with 're_' and 3 first letters should be skipped
+  char *restream_stream_key_marker = "re_";
+  if (strncmp(stream_key, restream_stream_key_marker, strlen(restream_stream_key_marker)) == 0) {
+    for (i = 0; i < len - 3; i++) {
+      copy_of_key[i] = copy_of_key[i + 3];
+    }
+
+    copy_of_key[i] = '\0';
+
+    len = strlen(copy_of_key);
+  }
+  free(restream_stream_key_marker);
+
   for (i = 0; i != len; i++) {
-    /* find the comma that divides the stream key */
-    if (stream_key[i] == '-' || stream_key[i] == ',') {
+    if (copy_of_key[i] == '-' || copy_of_key[i] == ',' || copy_of_key[i] == '_') {
       /* stream key gets copied */
-      strcpy_s(key, MAX_KEY_LEN, stream_key+i+1);
+      strcpy_s(key, MAX_KEY_LEN, copy_of_key+i+1);
 
       /* Now get the channel id */
-      char * copy_of_key = _strdup(stream_key);
       copy_of_key[i] = '\0';
       *chan_id = atol(copy_of_key);
-      free(copy_of_key);
 
+      free(copy_of_key);
       return TRUE;
     }
   }
 
-    return FALSE;
+  free(copy_of_key);
+  return FALSE;
 }
 
 

--- a/libftl/ftl-sdk.c
+++ b/libftl/ftl-sdk.c
@@ -418,13 +418,17 @@ FTL_API char* ftl_status_code_to_string(ftl_status_t status) {
 BOOL _get_chan_id_and_key(const char *stream_key, uint32_t *chan_id, char *key) {
   size_t len, i = 0;
 
+  if (stream_key == null) {
+    return FALSE;
+  }
+
   char * copy_of_key = _strdup(stream_key);
 
   len = strlen(stream_key);
 
   // Restream.io stream keys start with 're_' and 3 first letters should be skipped
   char *restream_stream_key_marker = "re_";
-  if (strncmp(stream_key, restream_stream_key_marker, strlen(restream_stream_key_marker)) == 0) {
+  if (len >= 3 && strncmp(stream_key, restream_stream_key_marker, strlen(restream_stream_key_marker)) == 0) {
     for (i = 0; i < len - 3; i++) {
       copy_of_key[i] = copy_of_key[i + 3];
     }

--- a/libftl/ftl-sdk.c
+++ b/libftl/ftl-sdk.c
@@ -437,7 +437,6 @@ BOOL _get_chan_id_and_key(const char *stream_key, uint32_t *chan_id, char *key) 
 
     len = strlen(copy_of_key);
   }
-  free(restream_stream_key_marker);
 
   for (i = 0; i != len; i++) {
     if (copy_of_key[i] == '-' || copy_of_key[i] == ',' || copy_of_key[i] == '_') {


### PR DESCRIPTION
Accepting this PR will allow encoders to deliver FTL streams to Restream, which will re-broadcast them to Mixer channels.

Restream stream keys format differs from the Mixer ones, luckily the only changes needed is to remove the first three symbols and allow using underscore as a separator between user id and the stream key.

Disclaimer: I'm not a C guy, so the code is most probably far from being good. Shout out if there is anything that can be improved, I will be happy to do so. 