### PR TITLE
Fix memory leak in ingest_find_best()

### DIFF
--- a/libftl/ingest.c
+++ b/libftl/ingest.c
@@ -338,6 +338,7 @@ char * ingest_find_best(ftl_stream_configuration_private_t *ftl) {
   }
 
   if ((data = (_tmp_ingest_thread_data_t *)malloc(sizeof(_tmp_ingest_thread_data_t) * ftl->ingest_count)) == NULL) {
+    free(handle);
     return NULL;
   }
 


### PR DESCRIPTION
This was found with Cppcheck. On a rare edge case memory is leaked.