### PR TITLE
Fix use of undefined pointer types in definitions

### DIFF
--- a/libftl/gettimeofday/gettimeofday.c
+++ b/libftl/gettimeofday/gettimeofday.c
@@ -44,7 +44,6 @@
 #define SEC_TO_NSEC(x) (((uint64_t)x) * NSEC_IN_SEC)
 
 #ifdef _WIN32
-#include <Windows.h>
 
 /* FILETIME of Jan 1 1970 00:00:00. */
 static const unsigned __int64 epoch = ((unsigned __int64)116444736000000000ULL);

--- a/libftl/gettimeofday/gettimeofday.h
+++ b/libftl/gettimeofday/gettimeofday.h
@@ -5,6 +5,10 @@
 
 #ifndef _WIN32
 #include <sys/time.h>
+#else
+#include <WinSock2.h>
+
+struct timezone;
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
This coincidentally also adds support for clang-cl. There's two problems being solved here.

The types `timeeval` and `timezone` are not defined where they're used in the gettimeofday.h header
`timezone` isn't defined by the WinAPI headers anywhere. `timeeval` is only defined in Winsock2.h.

The implementation of `gettimeofday()` here doesn't actually use the `timezone` structure so it may be defined as an opaque pointer without definition. `timeeval` is used however so it must have a definition, so we must include Winsock2.h in the header. Since the definition in the header didn't originally have a type associated with it, it could be interpreted as a different type from that of the one provided by WinSock2.h. clang-cl believes it to be an anonymous structure in the header so it thinks the function type is different between header declaration and implementation.