### PR TITLE
Fix typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 2.8.0)
 enable_language(C)
 project(libftl)
 
-option(DISABLE_AUTO_INGEST "Set to TRUE to disable auto ingest feature which removes curl and jansson dependancies" FALSE)
+option(DISABLE_AUTO_INGEST "Set to TRUE to disable auto ingest feature which removes curl and jansson dependencies" FALSE)
 MESSAGE(STATUS "FTL DISABLE_AUTO_INGEST: " ${DISABLE_AUTO_INGEST})
 
 option(DISABLE_FTL_APP "Set to TRUE to disable including the ftl app in the cmake output." FALSE)

--- a/Doxyfile
+++ b/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         = 0.1
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Source Developement Kit for Mixer's FTL Protocol"
+PROJECT_BRIEF          = "Source Development Kit for Mixer's FTL Protocol"
 
 # With the PROJECT_LOGO tag one can specify an logo or icon that is included in
 # the documentation. The maximum height of the logo should not exceed 55 pixels
@@ -1947,7 +1947,7 @@ PREDEFINED             =
 EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
-# remove all refrences to function-like macros that are alone on a line, have an
+# remove all references to function-like macros that are alone on a line, have an
 # all uppercase name, and do not end with a semicolon. Such function macros are
 # typically used for boiler-plate code, and will confuse the parser if not
 # removed.

--- a/ftl_app/main.c
+++ b/ftl_app/main.c
@@ -394,7 +394,7 @@ static void *ftl_status_thread(void *data)
         continue;
       }
 
-    /*dont reconnect for speed test*/
+    /*don't reconnect for speed test*/
     if (speedtest_duration) {
       continue;
     }

--- a/ftl_app/main.h
+++ b/ftl_app/main.h
@@ -33,7 +33,7 @@
  * header definitions without it as the winsock 1.1 API is in windows.h vs
  * ws2_32.h.
  *
- * Yay for backwards source compatability
+ * Yay for backwards source compatibility
  **/
 
 #define WIN32_LEAN_AND_MEAN 1


### PR DESCRIPTION
Found via `codespell -q 3 -S ./lib*,*.ini  -L aci,dur,iff,mut,numer,uint`