### PR TITLE
E2k support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,17 @@ MESSAGE(STATUS "FTL DISABLE_FTL_APP: " ${DISABLE_FTL_APP})
 option(FTL_STATIC_COMPILE "Set to TRUE if you want ftl to be compiled as a static lib. If TRUE, the program will want to statically link to the ftl cmake object." FALSE)
 MESSAGE(STATUS "FTL FTL_STATIC_COMPILE: " ${FTL_STATIC_COMPILE})
 
+include(CheckCCompilerFlag)
+
+if(LOWERCASE_CMAKE_SYSTEM_PROCESSOR MATCHES "e2k")
+	foreach(TEST_C_FLAG "-Wno-unused-parameter" "-Wno-pointer-sign" "-Wno-unused-variable" "-Wno-sign-compare" "-Wno-maybe-uninitialized")
+		CHECK_C_COMPILER_FLAG(${TEST_C_FLAG} C_COMPILER_SUPPORTS_FLAG_${TEST_C_FLAG})
+		if(C_COMPILER_SUPPORTS_FLAG_${TEST_C_FLAG})
+			set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${TEST_C_FLAG}")
+		endif()
+	endforeach()
+endif()
+
 find_package(Threads REQUIRED)
 
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/ftl_app/bitstream.c
+++ b/ftl_app/bitstream.c
@@ -1,3 +1,4 @@
+#include "dec_obj.h"
 #include "utils.h"
 #include "bitstream.h"
 

--- a/ftl_app/main.c
+++ b/ftl_app/main.c
@@ -22,6 +22,7 @@
  * SOFTWARE.
  **/
 
+#include "ftl.h"
 #include "main.h"
 #include "gettimeofday.h"
 #ifdef _WIN32
@@ -34,6 +35,7 @@
 #include <pthread.h>
 #include <sys/time.h>
 #endif
+#include <string.h>
 #include "file_parser.h"
 
 void sleep_ms(int ms)

--- a/ftl_app/main.c
+++ b/ftl_app/main.c
@@ -427,7 +427,7 @@ static void *ftl_status_thread(void *data)
     {
       ftl_packet_stats_msg_t *p = &status.msg.pkt_stats;
 
-      printf("Avg packet send per second %3.1f, total nack requests %d\n",
+      printf("Avg packet send per second %3.1f, total nack requests %ld\n",
              (float)p->sent * 1000.f / p->period,
              p->nack_reqs);
     }

--- a/libftl/ftl_private.h
+++ b/libftl/ftl_private.h
@@ -315,7 +315,7 @@ typedef struct _ftl_ingest_t {
 typedef struct
 {
     ftl_handle_t* handle;
-    BOOL(*change_bitrate_callback)(void*, uint64_t);
+    int(*change_bitrate_callback)(void*, uint64_t);
     void* context;
     uint64_t initial_encoding_bitrate;
     uint64_t max_encoding_bitrate;

--- a/libftl/ingest.c
+++ b/libftl/ingest.c
@@ -335,7 +335,7 @@ cleanup:
   
   ftl->ingest_count = total_ingest_cnt;
   
-  return total_ingest_cnt;
+  return (OS_THREAD_ROUTINE)total_ingest_cnt;
 }
 
 char * ingest_find_best(ftl_stream_configuration_private_t *ftl) {


### PR DESCRIPTION
This pull request introduces support for warningless building of ftl-sdk as a requirement of [obs-studio](https://github.com/obsproject/obs-studio) on Elbrus hardware platform (which is based on Russian [Elbrus](https://en.wikipedia.org/wiki/Elbrus-8S) CPU family) with its native lcc (eLbrus Compiler Collection) compiler.

As currently Elbrus-based stations are introduced into general puprose applications, including video streaming and recording, it is better to have OBS buildable on this platform directly from upstream without any warnings, rather than being patched with some specific patches prior to building, or producing mass of irrelevant warnings while being built.

This was:

* Built on Elbrus workstation (e2k-linux-gnu);
* Built on x86_64 workstation (x86_64-linux-gnu) to be sure that nothing is broken on x86_64.

Details of Elbrus workstation:

* CPU: Elbrus-8C (formerly Elbrus-8S) running on 1300 MHz
* Motherboard: E8C-EATX
* OS: OS Elbrus 5.0-rc2
* GPU: Advanced Micro Devices, Inc. [AMD/ATI] Vega 10 XL/XT [Radeon RX Vega 56/64] (rev c1)
* Kernel: 5.4.0-1.1-e8c
* Compiler: lcc:1.24.09:Feb-11-2020:e2k-v4-linux (gcc (GCC) 7.3.0 compatible)

Details of x86_64 workstation:

* CPU: AMD Ryzen Threadripper 2990WX 32-Core Processor running at 3.0 GHz
* Motherboard: MSI X399 SLI PLUS (MS-7B09)
* GPU: Advanced Micro Devices, Inc. [AMD/ATI] Caicos [Radeon HD 6450/7450/8450 / R5 230 OEM]
* OS: Ubuntu 18.04.5 LTS
* Kernel: 5.3.0-28-generic #30~18.04.1-Ubuntu
* Compiler: gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0

Results:

Successfully performed `mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=Release .. && make -j16 && sudo make install`; no suspicious behavior found, no warnings produced on e2k; `-Wint-to-pointer-cast`  produced at `libftl/ingest.c:338:10` on x86_64, but this seems to be unavoidable considering return type of `_ingest_get_hosts()`.